### PR TITLE
Rename FreeSolv solutes from nonsensical "binders" to "solutes"

### DIFF
--- a/examples/hydration/freesolv/yank.yaml
+++ b/examples/hydration/freesolv/yank.yaml
@@ -8,7 +8,7 @@ options:
 
 # Configure the specific molecules we will use for our systems
 molecules:
-  binders:
+  solutes:
     # .smiles files are treated the same as .cvs files
     filepath: freesolv-mini.smiles
     antechamber:

--- a/examples/hydration/freesolv/yank.yaml
+++ b/examples/hydration/freesolv/yank.yaml
@@ -20,6 +20,7 @@ solvents:
     nonbonded_method: PME
     nonbonded_cutoff: 9*angstroms
     clearance: 16*angstroms
+    solvent_model: tip4pew
   GBSA:
     nonbonded_method: NoCutoff
     implicit_solvent: OBC2

--- a/examples/hydration/freesolv/yank.yaml
+++ b/examples/hydration/freesolv/yank.yaml
@@ -28,7 +28,7 @@ solvents:
 
 systems:
   freesolv-hydration:
-    solute: binders
+    solute: solutes
     solvent1: !Combinatorial [pme, GBSA]
     solvent2: vacuum
     leap:


### PR DESCRIPTION
This PR changes FreeSolv solutes from the name `binders` to `solutes`