### PR TITLE
Test Yaml syntax only and update example files accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,17 @@ install:
   # Activate the test environment
   - conda activate test
   # Build the recipe
-  - conda build devtools/conda-recipe
+  - conda build devtools/conda-recipe --no-test
   # Install the package
   - conda install --use-local ${PACKAGENAME}
   # Install testing dependencies
-  - conda install --quiet nose nose-timer pytest
+  - conda install --quiet pytest
   # Install OpenEye dependencies
   - pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits && python -c "import openeye; print(openeye.__version__)"
+
+  script:
   # Test the package
-  - cd tests
-  - pytest test_syntax.py
-  - nosetests --nocapture --verbosity=2 --with-timer -a '!slow' test_examples.py
-  - cd ..
+  - pytest -m 'not slow'
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,10 @@ script:
   # Install OpenEye dependencies
   - pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Test the package
-  - cd tests && pytest test_syntax.py; cd ..
-  - cd tests && nosetests . --nocapture --verbosity=2 --with-timer -a '!slow' && cd ..
+  - cd tests
+  - pytest test_syntax.py
+  - nosetests . --nocapture --verbosity=2 --with-timer -a '!slow'
+  - cd ..
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   # Test the package
   - cd tests
   - pytest test_syntax.py
-  - nosetests . --nocapture --verbosity=2 --with-timer -a '!slow'
+  - nosetests --nocapture --verbosity=2 --with-timer -a '!slow' test_examples.py
   - cd ..
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,16 @@ before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == false ] ; then echo "OpenEye license will not be installed in pull request."; fi
 
 install:
-  - source devtools/travis-ci/install.sh
-  - export PYTHONUNBUFFERED=true
-
-script:
   # Create a test environment
   - conda create --yes -n test python=$python
   # Activate the test environment
-  - source activate test
-  - conda install --yes --quiet pip
+  - conda activate test
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package
-  - conda install --yes --use-local ${PACKAGENAME}
+  - conda install --use-local ${PACKAGENAME}
   # Install testing dependencies
-  - conda install --yes --quiet nose nose-timer pytest
+  - conda install --quiet nose nose-timer pytest
   # Install OpenEye dependencies
   - pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Test the package

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ install:
 
 env:
   matrix:
-    - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
+    - python=3.7  CONDA_PY=37
 
   global:
     - ORGNAME="omnia"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,11 @@ script:
   # Install the package
   - conda install --yes --use-local ${PACKAGENAME}
   # Install testing dependencies
-  - conda install --yes --quiet nose nose-timer
+  - conda install --yes --quiet nose nose-timer pytest
   # Install OpenEye dependencies
   - pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Test the package
+  - cd tests && pytest test_syntax.py; cd ..
   - cd tests && nosetests . --nocapture --verbosity=2 --with-timer -a '!slow' && cd ..
 
 env:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,18 +8,10 @@ source:
 requirements:
   build:
     - yank >=0.17.0
-    - ambermini 16.16.0 6
 
   run:
     - yank >=0.17.0
-    - ambermini 16.16.0 6
 
-test:
-  requires:
-    - nose
-    - nose-timer
-  imports:
-    - yank
 
 about:
   home: https://github.com/choderalab/yank-examples

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,7 +3,7 @@ pushd .
 cd $HOME
 
 # Install Miniconda
-MINICONDA=Miniconda2-latest-Linux-x86_64.sh
+MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget -q http://repo.continuum.io/miniconda/$MINICONDA
@@ -11,16 +11,21 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1
 fi
-bash $MINICONDA -b -p $MINICONDA_HOME
+bash $MINICONDA -bup $MINICONDA_HOME
 
 # Configure miniconda
 export PIP_ARGS="-U"
-export PATH=$MINICONDA_HOME/bin:$PATH
+source $MINICONDA_HOME/etc/profile.d/conda.sh
+# Reset default settings
+rm ~/.condarc || true
+# Update base environment
+conda activate
 conda config --add channels omnia/label/dev
 conda config --add channels omnia
 conda config --add channels conda-forge
-conda update -yq conda
-conda install --yes conda-build jinja2 anaconda-client pip
+conda config --set always_yes yes
+conda update -yq conda pip
+conda install --yes conda-build jinja2 anaconda-client
 
 # Restore original directory
 popd

--- a/examples/binding/abl-imatinib/explicit.yaml
+++ b/examples/binding/abl-imatinib/explicit.yaml
@@ -56,5 +56,4 @@ experiments:
   protocol: absolute-binding
   restraint:
     type: Boresch
-    rigidify: 15*degrees
 

--- a/examples/binding/abl-imatinib/explicit.yaml
+++ b/examples/binding/abl-imatinib/explicit.yaml
@@ -2,11 +2,11 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 3000
-  nsteps_per_iteration: 500
+  default_number_of_iterations: 3000
+  default_nsteps_per_iteration: 500
   temperature: 300*kelvin
   pressure: 1*atmosphere
-  timestep: 2.0*femtoseconds
+  default_timestep: 2.0*femtoseconds
   output_dir: explicit
   resume_setup: yes
   resume_simulation: yes

--- a/examples/binding/abl-imatinib/implicit.yaml
+++ b/examples/binding/abl-imatinib/implicit.yaml
@@ -2,10 +2,10 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 3000
-  nsteps_per_iteration: 500
+  default_number_of_iterations: 3000
+  default_nsteps_per_iteration: 500
   temperature: 300*kelvin
-  timestep: 2.0*femtoseconds
+  default_timestep: 2.0*femtoseconds
   platform: CUDA
   output_dir: implicit
   resume_setup: yes

--- a/examples/binding/host-guest/repex.yaml
+++ b/examples/binding/host-guest/repex.yaml
@@ -2,7 +2,7 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 500
+  default_number_of_iterations: 500
   temperature: 300*kelvin
   pressure: 1*atmospheres
   output_dir: output # Does not have to be set, but we do here to show the different outputs

--- a/examples/binding/t4-lysozyme/all-ligands-explicit.yaml
+++ b/examples/binding/t4-lysozyme/all-ligands-explicit.yaml
@@ -2,7 +2,7 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 500
+  default_number_of_iterations: 500
   temperature: 300*kelvin
   pressure: 1*atmosphere
   output_dir: all-ligands-explicit-output

--- a/examples/binding/t4-lysozyme/all-ligands-implicit.yaml
+++ b/examples/binding/t4-lysozyme/all-ligands-implicit.yaml
@@ -2,7 +2,7 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 500
+  default_number_of_iterations: 500
   temperature: 300*kelvin
   pressure: null
   output_dir: all-ligands-implicit-output

--- a/examples/binding/t4-lysozyme/p-xylene-explicit.yaml
+++ b/examples/binding/t4-lysozyme/p-xylene-explicit.yaml
@@ -2,7 +2,7 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 500
+  default_number_of_iterations: 500
   temperature: 300*kelvin
   pressure: 1*atmosphere # To run with NVT ensemble, set this option to "null". Defaults to 1 atm if excluded
   platform: CUDA

--- a/examples/binding/t4-lysozyme/p-xylene-implicit.yaml
+++ b/examples/binding/t4-lysozyme/p-xylene-implicit.yaml
@@ -2,7 +2,7 @@
 options:
   minimize: yes
   verbose: yes
-  number_of_iterations: 500
+  default_number_of_iterations: 500
   temperature: 300*kelvin
   pressure: null
   output_dir: p-xylene-implicit-output

--- a/examples/hydration/phenol/explicit.yaml
+++ b/examples/hydration/phenol/explicit.yaml
@@ -2,7 +2,7 @@ options:
   minimize: yes
   verbose: yes
   output_dir: explicit
-  number_of_iterations: 1000
+  default_number_of_iterations: 1000
   temperature: 300*kelvin
   pressure: 1*atmosphere
 

--- a/examples/hydration/phenol/implicit.yaml
+++ b/examples/hydration/phenol/implicit.yaml
@@ -2,7 +2,7 @@ options:
   minimize: yes
   verbose: yes
   output_dir: implicit
-  number_of_iterations: 1000
+  default_number_of_iterations: 1000
   temperature: 300*kelvin
   pressure: null
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,8 +21,7 @@ import re
 
 import openmoltools as omt
 
-from nose.plugins.attrib import attr
-from unittest import skipIf
+import pytest
 
 import yank
 
@@ -163,7 +162,7 @@ def run_examples(example_directory, yaml_name):
     return
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_t4_p_xylene_explicit():
     """
     Test p-xylene binding to t4 lysozyme example in explicit solvent
@@ -173,7 +172,7 @@ def test_t4_p_xylene_explicit():
     run_examples(example_dir, yaml_name)
 
 
-#@attr('slow')
+@pytest.mark.slow
 def test_t4_p_xylene_implicit():
     """
     Test p-xylene binding to t4 lysozyme example in implicit solvent
@@ -183,8 +182,8 @@ def test_t4_p_xylene_implicit():
     run_examples(example_dir, yaml_name)
 
 
-@attr('slow')
-@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
+@pytest.mark.slow
+@pytest.mark.skipif(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
 def test_t4_all_ligands_explicit():
     """
     Test that the all-binders to t4 lysozyme example works in explicit solvent
@@ -195,8 +194,8 @@ def test_t4_all_ligands_explicit():
     run_examples(example_dir, yaml_name)
 
 
-#@attr('slow')
-@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
+@pytest.mark.slow
+@pytest.mark.skipif(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
 def test_t4_all_ligands_implicit():
     """
     Test that the all-binders to t4 lysozyme example works in implicit solvent
@@ -207,7 +206,7 @@ def test_t4_all_ligands_implicit():
     run_examples(example_dir, yaml_name)
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_hydration_phenol_implicit():
     """
     Test that the phenol hydration implicit example
@@ -217,7 +216,7 @@ def test_hydration_phenol_implicit():
     run_examples(example_dir, yaml_name)
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_hydration_phenol_explicit():
     """
     Test that the phenol hydration explicit example
@@ -227,8 +226,8 @@ def test_hydration_phenol_explicit():
     run_examples(example_dir, yaml_name)
 
 
-#@attr('slow')
-@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
+@pytest.mark.slow
+@pytest.mark.skipif(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
 def test_binding_host_guest():
     """
     Test the host guest binding example
@@ -238,8 +237,8 @@ def test_binding_host_guest():
     run_examples(example_dir, yaml_name)
 
 
-#@attr('slow')
-@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
+@pytest.mark.slow
+@pytest.mark.skipif(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
 def test_hydration_freesolv():
     """
     Test that the hydration freesolv database example works

--- a/tests/test_files_exist.py
+++ b/tests/test_files_exist.py
@@ -29,8 +29,7 @@ def _dirs_equal(comparer):
     - files with different names
     """
     yield all(not bool(x) for x in (comparer.diff_files, comparer.left_only, comparer.right_only))
-    for name, subdir in comparer.subdirs.items():
-        print(name)
+    for subdir in comparer.subdirs.values():
         yield from _dirs_equal(subdir)
 
 

--- a/tests/test_files_exist.py
+++ b/tests/test_files_exist.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+
+# =============================================================================================
+# MODULE DOCSTRING
+# =============================================================================================
+
+"""
+Test YAML syntax in examples.
+
+"""
+
+# =============================================================================================
+# GLOBAL IMPORTS
+# =============================================================================================
+
+from pathlib import Path
+import filecmp
+import os
+import sys
+
+import pytest
+import yaml
+
+
+def _dirs_equal(comparer):
+    """
+    Recurse over subdirs testing that there are no:
+    - files with same name, but different contents
+    - files with different names
+    """
+    yield all(not bool(x) for x in (comparer.diff_files, comparer.left_only, comparer.right_only))
+    for name, subdir in comparer.subdirs.items():
+        print(name)
+        yield from _dirs_equal(subdir)
+
+
+def test_files_exist():
+    """
+    Compare examples copied to $PREFIX/share/yank
+    and those available in the current repo. They should match!
+    """
+    repo_examples = Path(__file__).parent.parent / 'examples'
+    prefix_examples = Path(sys.prefix) / 'share' / 'yank' / 'examples'
+    assert repo_examples.is_dir()
+    assert prefix_examples.is_dir()
+    comparer = filecmp.dircmp(repo_examples, prefix_examples)
+    assert all(_dirs_equal(comparer))

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -21,7 +21,9 @@ import yaml
 import openmoltools as omt
 from yank.experiment import ExperimentBuilder, YankLoader
 
+
 EXAMPLES = Path(__file__).parent.parent / 'examples'
+
 
 @pytest.mark.parametrize("path", [
     'hydration/phenol/explicit.yaml',
@@ -40,9 +42,10 @@ def test_yaml_syntax(path):
     Test syntax only. If successful, `ExperimentBuilder`
     will be able to initialize safely.
     """
-    path = str(EXAMPLES / path)
+    path = EXAMPLES / path
     with omt.utils.temporary_cd(str(path.parent)):
-        builder = ExperimentBuilder(script=path)
+        builder = ExperimentBuilder(script=str(path))
+
 
 @pytest.mark.parametrize("path", [
     'binding/t4-lysozyme/p-xylene-explicit.yaml',
@@ -54,9 +57,9 @@ def test_yaml_syntax_cuda(path):
     to avoid errors unrelated to syntax if the test machine
     does not have CUDA enabled
     """
-    path = str(EXAMPLES / path)
+    path = EXAMPLES / path
     with omt.utils.temporary_cd(str(path.parent)):
-        with open(path) as f:
+        with open(str(path)) as f:
             data = yaml.load(f, Loader=YankLoader)
         del data['options']['platform']
         builder = ExperimentBuilder(script=data)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -54,7 +54,7 @@ def test_yaml_syntax_cuda(path):
     to avoid errors unrelated to syntax if the test machine
     does not have CUDA enabled
     """
-    path = os.path.join(EXAMPLES, path)
+    path = EXAMPLES / path
     with omt.utils.temporary_cd(os.path.dirname(path)):
         with open(path) as f:
             data = yaml.load(f, Loader=YankLoader)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -15,9 +15,11 @@ Test YAML syntax in examples.
 
 import os
 import pytest
-import openmoltools as omt
 from pathlib import Path
-from yank.experiment import ExperimentBuilder
+import yaml
+
+import openmoltools as omt
+from yank.experiment import ExperimentBuilder, YankLoader
 
 EXAMPLES = Path(__file__).parent.parent / 'examples'
 
@@ -26,18 +28,35 @@ EXAMPLES = Path(__file__).parent.parent / 'examples'
     'hydration/phenol/implicit.yaml',
     'hydration/freesolv/sams.yaml',
     'binding/abl-imatinib/explicit.yaml',
-    'binding/abl-imatinib/implicit.yaml',
     'binding/abl-imatinib/sams.yaml',
-    'binding/host-guest/sams-explicit/experiments/analysis.yaml',
-    'binding/host-guest/sams-explicit/experiments/experiments.yaml',
     'binding/host-guest/repex.yaml',
     'binding/host-guest/sams.yaml',
     'binding/t4-lysozyme/all-ligands-implicit.yaml',
     'binding/t4-lysozyme/p-xylene-implicit.yaml',
-    'binding/t4-lysozyme/p-xylene-explicit.yaml',
     'binding/t4-lysozyme/all-ligands-explicit.yaml',
 ])
 def test_yaml_syntax(path):
+    """
+    Test syntax only. If successful, `ExperimentBuilder`
+    will be able to initialize safely.
+    """
     path = os.path.join(EXAMPLES, path)
     with omt.utils.temporary_cd(os.path.dirname(path)):
         builder = ExperimentBuilder(script=path)
+
+@pytest.mark.parametrize("path", [
+    'binding/t4-lysozyme/p-xylene-explicit.yaml',
+    'binding/abl-imatinib/implicit.yaml',
+])
+def test_yaml_syntax_cuda(path):
+    """
+    Same as test_yaml_syntax, but removing `platform: CUDA`
+    to avoid errors unrelated to syntax if the test machine
+    does not have CUDA enabled
+    """
+    path = os.path.join(EXAMPLES, path)
+    with omt.utils.temporary_cd(os.path.dirname(path)):
+        with open(path) as f:
+            data = yaml.load(f, Loader=YankLoader)
+        del data['options']['platform']
+        builder = ExperimentBuilder(script=data)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+# =============================================================================================
+# MODULE DOCSTRING
+# =============================================================================================
+
+"""
+Test YAML syntax in examples.
+
+"""
+
+# =============================================================================================
+# GLOBAL IMPORTS
+# =============================================================================================
+
+import os
+import pytest
+import openmoltools as omt
+from pathlib import Path
+from yank.experiment import ExperimentBuilder
+
+EXAMPLES = Path(__file__).parent.parent / 'examples'
+
+@pytest.mark.parametrize("path", [
+    'hydration/phenol/explicit.yaml',
+    'hydration/phenol/implicit.yaml',
+    'hydration/freesolv/sams.yaml',
+    'binding/abl-imatinib/explicit.yaml',
+    'binding/abl-imatinib/implicit.yaml',
+    'binding/abl-imatinib/sams.yaml',
+    'binding/host-guest/sams-explicit/experiments/analysis.yaml',
+    'binding/host-guest/sams-explicit/experiments/experiments.yaml',
+    'binding/host-guest/repex.yaml',
+    'binding/host-guest/sams.yaml',
+    'binding/t4-lysozyme/all-ligands-implicit.yaml',
+    'binding/t4-lysozyme/p-xylene-implicit.yaml',
+    'binding/t4-lysozyme/p-xylene-explicit.yaml',
+    'binding/t4-lysozyme/all-ligands-explicit.yaml',
+])
+def test_yaml_syntax(path):
+    path = os.path.join(EXAMPLES, path)
+    with omt.utils.temporary_cd(os.path.dirname(path)):
+        builder = ExperimentBuilder(script=path)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -40,7 +40,7 @@ def test_yaml_syntax(path):
     Test syntax only. If successful, `ExperimentBuilder`
     will be able to initialize safely.
     """
-    path = os.path.join(EXAMPLES, path)
+    path = EXAMPLES / path
     with omt.utils.temporary_cd(os.path.dirname(path)):
         builder = ExperimentBuilder(script=path)
 

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -40,8 +40,8 @@ def test_yaml_syntax(path):
     Test syntax only. If successful, `ExperimentBuilder`
     will be able to initialize safely.
     """
-    path = EXAMPLES / path
-    with omt.utils.temporary_cd(path.parent):
+    path = str(EXAMPLES / path)
+    with omt.utils.temporary_cd(str(path.parent)):
         builder = ExperimentBuilder(script=path)
 
 @pytest.mark.parametrize("path", [
@@ -54,8 +54,8 @@ def test_yaml_syntax_cuda(path):
     to avoid errors unrelated to syntax if the test machine
     does not have CUDA enabled
     """
-    path = EXAMPLES / path
-    with omt.utils.temporary_cd(path.parent):
+    path = str(EXAMPLES / path)
+    with omt.utils.temporary_cd(str(path.parent)):
         with open(path) as f:
             data = yaml.load(f, Loader=YankLoader)
         del data['options']['platform']

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -41,7 +41,7 @@ def test_yaml_syntax(path):
     will be able to initialize safely.
     """
     path = EXAMPLES / path
-    with omt.utils.temporary_cd(os.path.dirname(path)):
+    with omt.utils.temporary_cd(path.parent):
         builder = ExperimentBuilder(script=path)
 
 @pytest.mark.parametrize("path", [
@@ -55,7 +55,7 @@ def test_yaml_syntax_cuda(path):
     does not have CUDA enabled
     """
     path = EXAMPLES / path
-    with omt.utils.temporary_cd(os.path.dirname(path)):
+    with omt.utils.temporary_cd(path.parent):
         with open(path) as f:
             data = yaml.load(f, Loader=YankLoader)
         del data['options']['platform']


### PR DESCRIPTION
Following conversation on #60, I have created a `pytest` test to validate the current examples. This partially overlaps with #68 in scope, but I am using different files. Maybe this is enough to make sure everything is at least being parsed. Running the whole simulation in CI is tricky due to time limits.

Known problems:

- I am using `pytest` while the other test uses `nosetest`.
- Two errors are still unfixed:

_examples/binding/host-guest/sams-explicit/experiments/experiments.yaml_ 

```
yank.experiment.YamlParseError: Experiment '' did not validate! Check the schema error below for details
sampler:
- unallowed value sams
```
_examples/binding/abl-imatinib/explicit.yaml_
```
yank.experiment.YamlParseError: Experiment 'AblSTISTI0' did not validate! Check the schema error below for details
restraint:
- 'Validation of constructor failed with: found unknown parameter rigidify'
```